### PR TITLE
Added Transition Names

### DIFF
--- a/SR-Unlimited/data/maps/6_Months_Later.srm.txt
+++ b/SR-Unlimited/data/maps/6_Months_Later.srm.txt
@@ -195,6 +195,7 @@ props {
       scene_name: "The barrens"
       confirmation_text: "Are you sure you wanna leave your miserable coffin motel? Have you left anything you need right now in your stash? (You will be able to access your stash later)."
     }
+    interaction_info_text: "Redmond Barrens"
   }
   lod: 0
 }
@@ -493,6 +494,7 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_Generic
+    interaction_info_text: "Wall Safe"
   }
   lod: 0
 }

--- a/SR-Unlimited/data/maps/Coffin Motel.srm.txt
+++ b/SR-Unlimited/data/maps/Coffin Motel.srm.txt
@@ -253,6 +253,7 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_Generic
+    interaction_info_text: "Wall Safe"
   }
   lod: 0
 }
@@ -289,6 +290,7 @@ props {
       }
     }
     interactionIcon: InteractionIcon_SceneTransition
+    interaction_info_text: "Redmond Barrens"
   }
   lod: 0
 }
@@ -499,6 +501,7 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_Inspect
+    interaction_info_text: "Rest"
   }
   lod: 0
 }

--- a/SR-Unlimited/data/maps/Downtown.srm.txt
+++ b/SR-Unlimited/data/maps/Downtown.srm.txt
@@ -39388,6 +39388,7 @@ props {
       }
     }
     interactionIcon: InteractionIcon_Inspect
+    interaction_info_text: "Tarislar Garden Apartments"
   }
   lod: 0
 }
@@ -39573,6 +39574,7 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_SceneTransition
+    interaction_info_text: "Rosco\'s"
   }
   lod: 0
 }
@@ -40465,7 +40467,7 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_SceneTransition
-    interaction_info_text: "Smells Bad"
+    interaction_info_text: "Sewers"
   }
   lod: 0
 }

--- a/SR-Unlimited/data/maps/Graveyard.srm.txt
+++ b/SR-Unlimited/data/maps/Graveyard.srm.txt
@@ -17323,7 +17323,7 @@ props {
       scene_name: "xalthu\'s remix"
       confirmation_text: "Are you sure you wish to descend into this catacomb?"
     }
-    interaction_info_text: "cracked catacomb"
+    interaction_info_text: "Cracked Catacomb"
   }
   lod: 0
 }
@@ -18246,7 +18246,7 @@ props {
       }
     }
     interactionIcon: InteractionIcon_Summon
-    interaction_info_text: "Mucky Looking Headstone"
+    interaction_info_text: "Festering Headstone"
   }
   lod: 0
 }
@@ -18312,7 +18312,7 @@ props {
       }
     }
     interactionIcon: InteractionIcon_Summon
-    interaction_info_text: "fresh grave"
+    interaction_info_text: "Fresh Grave"
   }
   lod: 0
 }
@@ -18333,7 +18333,7 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_SceneTransition
-    interaction_info_text: "Smells Bad"
+    interaction_info_text: "Sewers"
   }
   lod: 0
 }

--- a/SR-Unlimited/data/maps/Low-Lifestyle_Apt.srm.txt
+++ b/SR-Unlimited/data/maps/Low-Lifestyle_Apt.srm.txt
@@ -1110,6 +1110,7 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_ItemPickup
+    interaction_info_text: "Locker"
   }
   lod: 0
 }
@@ -2292,6 +2293,7 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_SceneTransition
+    interaction_info_text: "Redmond Barrens"
   }
   lod: 0
 }
@@ -2315,6 +2317,7 @@ props {
       }
     }
     interactionIcon: InteractionIcon_Generic
+    interaction_info_text: "Craft"
   }
   lod: 0
 }
@@ -2333,6 +2336,7 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_Inspect
+    interaction_info_text: "Rest"
   }
   lod: 0
 }

--- a/SR-Unlimited/data/maps/NorthCity.srm.txt
+++ b/SR-Unlimited/data/maps/NorthCity.srm.txt
@@ -97570,7 +97570,7 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_SceneTransition
-    interaction_info_text: "Smells Bad"
+    interaction_info_text: "Sewers"
   }
   lod: 0
 }

--- a/SR-Unlimited/data/maps/Penumbra District.srm.txt
+++ b/SR-Unlimited/data/maps/Penumbra District.srm.txt
@@ -48471,7 +48471,7 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_SceneTransition
-    interaction_info_text: "Puyallup Barrens"
+    interaction_info_text: "The Puyallup Barrens"
   }
   lod: 0
 }
@@ -48978,7 +48978,7 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_SceneTransition
-    interaction_info_text: "Smells Bad"
+    interaction_info_text: "Sewers"
   }
   lod: 0
 }

--- a/SR-Unlimited/data/maps/Raven's Nest.srm.txt
+++ b/SR-Unlimited/data/maps/Raven's Nest.srm.txt
@@ -2361,6 +2361,7 @@ props {
       }
     }
     interactionIcon: InteractionIcon_SceneTransition
+    interaction_info_text: "Redmond Barrens"
   }
   lod: 0
 }

--- a/SR-Unlimited/data/maps/Rosco's Store.srm.txt
+++ b/SR-Unlimited/data/maps/Rosco's Store.srm.txt
@@ -1963,6 +1963,7 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_SceneTransition
+    interaction_info_text: "Downtown"
   }
   lod: 0
 }

--- a/SR-Unlimited/data/maps/Royale Apartments.srm.txt
+++ b/SR-Unlimited/data/maps/Royale Apartments.srm.txt
@@ -10325,6 +10325,7 @@ props {
       }
     }
     interactionIcon: InteractionIcon_SceneTransition
+    interaction_info_text: "Downtown"
   }
   lod: 0
 }

--- a/SR-Unlimited/data/maps/Run Location-AG Chemicals.srm.txt
+++ b/SR-Unlimited/data/maps/Run Location-AG Chemicals.srm.txt
@@ -1294,7 +1294,7 @@ props {
       }
     }
     interactionIcon: InteractionIcon_Generic
-    interaction_info_text: ""
+    interaction_info_text: "Northside"
   }
   lod: 0
 }

--- a/SR-Unlimited/data/maps/Run Location-Bottling Plant.srm.txt
+++ b/SR-Unlimited/data/maps/Run Location-Bottling Plant.srm.txt
@@ -1787,7 +1787,7 @@ props {
       }
     }
     interactionIcon: InteractionIcon_Generic
-    interaction_info_text: "Back to the docks"
+    interaction_info_text: "The Docks"
   }
   lod: 0
 }

--- a/SR-Unlimited/data/maps/Run Location-Generax Labs.srm.txt
+++ b/SR-Unlimited/data/maps/Run Location-Generax Labs.srm.txt
@@ -1716,7 +1716,7 @@ props {
       }
     }
     interactionIcon: InteractionIcon_Generic
-    interaction_info_text: ""
+    interaction_info_text: "Northside"
   }
   lod: 0
 }

--- a/SR-Unlimited/data/maps/Run Location-Puyallup Gang (No Run).srm.txt
+++ b/SR-Unlimited/data/maps/Run Location-Puyallup Gang (No Run).srm.txt
@@ -1794,7 +1794,7 @@ props {
       }
     }
     interactionIcon: InteractionIcon_Generic
-    interaction_info_text: ""
+    interaction_info_text: "The Puyallup Barrens"
   }
   lod: 0
 }

--- a/SR-Unlimited/data/maps/Run Location-Puyallup Gang.srm.txt
+++ b/SR-Unlimited/data/maps/Run Location-Puyallup Gang.srm.txt
@@ -1794,7 +1794,7 @@ props {
       }
     }
     interactionIcon: InteractionIcon_Generic
-    interaction_info_text: ""
+    interaction_info_text: "The Puyallup Barrens"
   }
   lod: 0
 }

--- a/SR-Unlimited/data/maps/Run Location-Rat's Nest.srm.txt
+++ b/SR-Unlimited/data/maps/Run Location-Rat's Nest.srm.txt
@@ -4256,7 +4256,7 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_SceneTransition
-    interaction_info_text: ""
+    interaction_info_text: "Redmond Barrens"
   }
   lod: 0
 }
@@ -49445,5 +49445,15 @@ props {
   idRef {
     id: "54517878363735ac05002e80"
   }
+  lod: 0
+}
+props {
+  name: "hive_storage_weaponCabinet"
+  gridPoint {
+    x: 112
+    y: 0
+    z: 33
+  }
+  orientation: ORIENTATION_E
   lod: 0
 }

--- a/SR-Unlimited/data/maps/Run Location-Telestrian R&D.srm.txt
+++ b/SR-Unlimited/data/maps/Run Location-Telestrian R&D.srm.txt
@@ -1786,7 +1786,7 @@ props {
       }
     }
     interactionIcon: InteractionIcon_Generic
-    interaction_info_text: ""
+    interaction_info_text: "Northside"
   }
   lod: 0
 }

--- a/SR-Unlimited/data/maps/SlumAPt.srm.txt
+++ b/SR-Unlimited/data/maps/SlumAPt.srm.txt
@@ -1386,6 +1386,7 @@ props {
       }
     }
     interactionIcon: InteractionIcon_SceneTransition
+    interaction_info_text: "Redmond Barrens"
   }
   lod: 0
 }
@@ -8049,6 +8050,7 @@ props {
       }
     }
     interactionIcon: InteractionIcon_Warp
+    interaction_info_text: "Upstairs"
   }
   lod: 0
 }
@@ -8084,6 +8086,7 @@ props {
       }
     }
     interactionIcon: InteractionIcon_Warp
+    interaction_info_text: "Downstairs"
   }
   lod: 0
 }

--- a/SR-Unlimited/data/maps/Small House.srm.txt
+++ b/SR-Unlimited/data/maps/Small House.srm.txt
@@ -137,6 +137,7 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_ItemPickup
+    interaction_info_text: "Safe"
   }
   lod: 0
 }
@@ -185,6 +186,7 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_Matrix
+    interaction_info_text: ""
   }
   lod: 0
 }
@@ -203,6 +205,7 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_Inspect
+    interaction_info_text: "Rest"
   }
   lod: 0
 }
@@ -2384,6 +2387,7 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_Inspect
+    interaction_info_text: "Craft"
   }
   lod: 0
 }
@@ -2403,6 +2407,7 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_SceneTransition
+    interaction_info_text: "Downtown"
   }
   lod: 0
 }

--- a/SR-Unlimited/data/maps/StreetDoc1.srm.txt
+++ b/SR-Unlimited/data/maps/StreetDoc1.srm.txt
@@ -856,15 +856,8 @@ props {
   interactionRoot {
     isEnabled: true
     interactionRadius: 1
-    prerequisites {
-      ops {
-        functionName: "No Condition"
-      }
-      ops {
-        functionName: "No Condition"
-      }
-    }
     interactionIcon: InteractionIcon_SceneTransition
+    interaction_info_text: "Downtown"
   }
   lod: 0
 }

--- a/SR-Unlimited/data/maps/Street_Doc(2).srm.txt
+++ b/SR-Unlimited/data/maps/Street_Doc(2).srm.txt
@@ -1587,6 +1587,7 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_SceneTransition
+    interaction_info_text: "The Penumbra District"
   }
   lod: 0
 }

--- a/SR-Unlimited/data/maps/The Docks3.srm.txt
+++ b/SR-Unlimited/data/maps/The Docks3.srm.txt
@@ -20341,7 +20341,7 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_SceneTransition
-    interaction_info_text: "Smells Bad"
+    interaction_info_text: "Sewers"
   }
   lod: 0
 }

--- a/SR-Unlimited/data/maps/The Jackal's Lantern.srm.txt
+++ b/SR-Unlimited/data/maps/The Jackal's Lantern.srm.txt
@@ -1229,6 +1229,7 @@ props {
       }
     }
     interactionIcon: InteractionIcon_SceneTransition
+    interaction_info_text: "Redmond Barrens"
   }
   lod: 0
 }

--- a/SR-Unlimited/data/maps/The Puyullup Barrens.srm.txt
+++ b/SR-Unlimited/data/maps/The Puyullup Barrens.srm.txt
@@ -2432,7 +2432,7 @@ props {
       }
     }
     interactionIcon: InteractionIcon_SceneTransition
-    interaction_info_text: "the Wild Yak Teppenyaki"
+    interaction_info_text: "The Wild Yak Teppenyaki"
   }
   lod: 0
 }
@@ -2646,7 +2646,7 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_SceneTransition
-    interaction_info_text: "the Penumbra district"
+    interaction_info_text: "The Penumbra District"
   }
   lod: 0
 }
@@ -3384,7 +3384,7 @@ props {
       }
     }
     interactionIcon: InteractionIcon_Inspect
-    interaction_info_text: "Closed until further notice"
+    interaction_info_text: "Closed Until Further Notice"
   }
   lod: 0
 }
@@ -3487,6 +3487,7 @@ props {
       }
     }
     interactionIcon: InteractionIcon_Inspect
+    interaction_info_text: "Warehouse"
   }
   lod: 0
 }
@@ -3558,7 +3559,7 @@ props {
       }
     }
     interactionIcon: InteractionIcon_Generic
-    interaction_info_text: ""
+    interaction_info_text: "Warehouse"
   }
   lod: 0
 }
@@ -55063,7 +55064,7 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_SceneTransition
-    interaction_info_text: "Smells Bad"
+    interaction_info_text: "Sewers"
   }
   lod: 0
 }

--- a/SR-Unlimited/data/maps/The Rat's Nest.srm.txt
+++ b/SR-Unlimited/data/maps/The Rat's Nest.srm.txt
@@ -20746,7 +20746,7 @@ props {
       conversationID: "58e04fad3037363b6789d1a7"
       turnToFace: true
     }
-    interaction_info_text: ""
+    interaction_info_text: "Gambling Terminal"
   }
   lod: 0
 }
@@ -59035,6 +59035,7 @@ props {
       }
     }
     interactionIcon: InteractionIcon_SceneTransition
+    interaction_info_text: "Redmond Barrens"
   }
   lod: 0
 }
@@ -74610,7 +74611,17 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_SceneTransition
-    interaction_info_text: "Smells Bad"
+    interaction_info_text: "Sewers"
   }
+  lod: 0
+}
+props {
+  name: "hive_storage_weaponCabinet"
+  gridPoint {
+    x: 0
+    y: 0
+    z: 30
+  }
+  orientation: ORIENTATION_E
   lod: 0
 }

--- a/SR-Unlimited/data/maps/Underground 93.srm.txt
+++ b/SR-Unlimited/data/maps/Underground 93.srm.txt
@@ -2712,6 +2712,7 @@ props {
       }
     }
     interactionIcon: InteractionIcon_SceneTransition
+    interaction_info_text: "Northside"
   }
   lod: 0
 }

--- a/SR-Unlimited/data/maps/Victor's Apartment.srm.txt
+++ b/SR-Unlimited/data/maps/Victor's Apartment.srm.txt
@@ -3663,6 +3663,7 @@ props {
       }
     }
     interactionIcon: InteractionIcon_SceneTransition
+    interaction_info_text: "Northside"
   }
   lod: 0
 }

--- a/SR-Unlimited/data/maps/Warehouse Safehouse Pre-SetUp.srm.txt
+++ b/SR-Unlimited/data/maps/Warehouse Safehouse Pre-SetUp.srm.txt
@@ -3178,6 +3178,7 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_SceneTransition
+    interaction_info_text: "The Puyallup Barrens"
   }
   lod: 0
 }

--- a/SR-Unlimited/data/maps/Xalthu's Catacomb.srm.txt
+++ b/SR-Unlimited/data/maps/Xalthu's Catacomb.srm.txt
@@ -2533,7 +2533,7 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_SceneTransition
-    interaction_info_text: "Back to the graveyard"
+    interaction_info_text: "The Graveyard"
   }
   lod: 0
 }

--- a/SR-Unlimited/data/maps/Yakuza Restaurant.srm.txt
+++ b/SR-Unlimited/data/maps/Yakuza Restaurant.srm.txt
@@ -1813,6 +1813,7 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_SceneTransition
+    interaction_info_text: "The Puyallup Barrens"
   }
   lod: 0
 }
@@ -3042,6 +3043,7 @@ props {
       scene_name: "Yakuza Lab"
       confirmation_text: "Head down into the basement?"
     }
+    interaction_info_text: "Downstairs"
   }
   lod: 0
 }

--- a/SR-Unlimited/data/maps/pistolera scrapyard.srm.txt
+++ b/SR-Unlimited/data/maps/pistolera scrapyard.srm.txt
@@ -4361,7 +4361,7 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_Generic
-    interaction_info_text: "the Surface"
+    interaction_info_text: "Downtown"
   }
   lod: 0
 }

--- a/SR-Unlimited/data/maps/shared_barrens.srm.txt
+++ b/SR-Unlimited/data/maps/shared_barrens.srm.txt
@@ -928,7 +928,7 @@ props {
       }
     }
     interactionIcon: InteractionIcon_SceneTransition
-    interaction_info_text: ""
+    interaction_info_text: "Stokers Coffin Motel"
   }
   lod: 0
 }
@@ -1014,6 +1014,7 @@ props {
       }
     }
     interactionIcon: InteractionIcon_Inspect
+    interaction_info_text: "Albino Dragon Apartments"
   }
   lod: 0
 }
@@ -1610,7 +1611,7 @@ props {
       }
     }
     interactionIcon: InteractionIcon_SceneTransition
-    interaction_info_text: "the Graveyard"
+    interaction_info_text: "The Graveyard"
   }
   lod: 0
 }
@@ -9220,23 +9221,6 @@ props {
   orientation: ORIENTATION_S
   idRef {
     id: "53ed577c386461a42d0026f6"
-  }
-  lod: 0
-}
-props {
-  name: "vfx_fx_flashingAlarm"
-  gridPoint {
-    x: 12.2
-    y: 3.4
-    z: 194.4
-  }
-  orientation: ORIENTATION_S
-  properties {
-    property_id: "fxScript"
-    string_value: "EnvironmentLoopFlashingAlarm"
-  }
-  idRef {
-    id: "53ed577c386461a42d0026f8"
   }
   lod: 0
 }
@@ -18396,23 +18380,6 @@ props {
   orientation: ORIENTATION_S
   idRef {
     id: "53ed577c386461a42d002a80"
-  }
-  lod: 0
-}
-props {
-  name: "vfx_fx_firebarrel"
-  gridPoint {
-    x: -56
-    y: 0
-    z: 190
-  }
-  orientation: ORIENTATION_S
-  properties {
-    property_id: "fxScript"
-    string_value: "CrowdBarrelFire"
-  }
-  idRef {
-    id: "53ed577c386461a42d002a81"
   }
   lod: 0
 }
@@ -33754,7 +33721,8 @@ props {
   interactionRoot {
     isEnabled: true
     interactionRadius: 1
-    interactionIcon: InteractionIcon_Generic
+    interactionIcon: InteractionIcon_Matrix
+    interaction_info_text: ""
   }
   lod: 0
 }
@@ -34624,7 +34592,7 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_SceneTransition
-    interaction_info_text: "Smells Bad"
+    interaction_info_text: "Sewers"
   }
   lod: 0
 }

--- a/SR-Unlimited/data/maps/shared_seamstressesunion.srm.txt
+++ b/SR-Unlimited/data/maps/shared_seamstressesunion.srm.txt
@@ -12955,6 +12955,7 @@ props {
     isEnabled: false
     interactionRadius: 1
     interactionIcon: InteractionIcon_Warp
+    interaction_info_text: "Upstairs"
   }
   lod: 0
 }
@@ -13108,6 +13109,7 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_Warp
+    interaction_info_text: "Downstairs"
   }
   lod: 0
 }
@@ -20519,6 +20521,7 @@ props {
     isEnabled: true
     interactionRadius: 1
     interactionIcon: InteractionIcon_SceneTransition
+    interaction_info_text: "The Penumbra District"
   }
   lod: 0
 }
@@ -20568,7 +20571,7 @@ props {
       }
     }
     interactionIcon: InteractionIcon_Warp
-    interaction_info_text: ""
+    interaction_info_text: "Upstairs"
   }
   lod: 0
 }


### PR DESCRIPTION
The names of transitions display the destined location when moused over. When left empty they just read "Transition". I named interactions in the hideouts, for example the bed interaction displays "Rest". Deleted a flashing traffic light FX in Redmond with no associated traffic light. Also added a weapon locker behind Set in so it looks like she's a weapon merchant. 