### PR TITLE
Add files via upload

### DIFF
--- a/SR-Unlimited/data/scenes/club penumbra.srt.txt
+++ b/SR-Unlimited/data/scenes/club penumbra.srt.txt
@@ -212,6 +212,34 @@ triggers {
     }
   }
   conditions {
+    ops {
+      functionName: "Comparison (int)"
+      args {
+        call_value {
+          functionName: "Get Story Variable (int)"
+          args {
+            string_value: "51f15c62336331d02c00440e"
+          }
+          args {
+            string_value: "StoryStep"
+          }
+        }
+      }
+      args {
+        call_value {
+          functionName: "Get Preset Value (int)"
+          args {
+            string_value: "Comparison Ops"
+          }
+          args {
+            int_value: 0
+          }
+        }
+      }
+      args {
+        int_value: 22
+      }
+    }
   }
   actions {
     ops {
@@ -335,6 +363,91 @@ triggers {
     id: "51fa3355336331dc47002221"
   }
   elseActions {
+    ops {
+      functionName: "Teleport Actor"
+      args {
+        call_value {
+          functionName: "All Actors on Team"
+          args {
+            call_value {
+              functionName: "Get Preset Value (string)"
+              args {
+                string_value: "FactionList"
+              }
+              args {
+                int_value: 0
+              }
+            }
+          }
+          args {
+            call_value {
+              functionName: "Get Preset Value (int)"
+              args {
+                string_value: "AllOrAny"
+              }
+              args {
+                int_value: 0
+              }
+            }
+          }
+          args {
+            call_value {
+              functionName: "Get Map Item (SceneDimension)"
+              args {
+                string_value: "Default"
+              }
+            }
+          }
+        }
+      }
+      args {
+        call_value {
+          functionName: "Specified Point (3D)"
+          args {
+            float_value: -12
+          }
+          args {
+            float_value: 0
+          }
+          args {
+            float_value: -16.8
+          }
+        }
+      }
+      args {
+        call_value {
+          functionName: "Get Preset Value (int)"
+          args {
+            string_value: "FacingDirection"
+          }
+          args {
+            int_value: 0
+          }
+        }
+      }
+      args {
+        call_value {
+          functionName: "Get Preset Value (int)"
+          args {
+            string_value: "TeleportMethod"
+          }
+          args {
+            int_value: 0
+          }
+        }
+      }
+    }
+    ops {
+      functionName: "Teleport Camera To Actor"
+      args {
+        call_value {
+          functionName: "Get Map Item (Player)"
+          args {
+            int_value: 0
+          }
+        }
+      }
+    }
   }
   is_oneshot: false
 }


### PR DESCRIPTION
In Club Penumbra when going downstairs there is a consistent weird bug where it would warp me downstairs with camera centered on Player 0, then center the camera back upstairs and immediately move the camera back downstairs centering on Player 0 again. I noticed that the trigger always starts a conversation conditioned on StoryStep 22 that starts StoryStep 23. I thought that conversation trigger is causing the camera to center on the last location of the player. I put a condition in the trigger itself to check if the StoryStep is 22. If not, it just sends you downstairs and centers camera. It seems to work. Now you can do downstairs from Club Penumbra without getting whiplash.  