### PR TITLE
HK: Fix calling Clockwork stalling the engine in the Docks and Rat's Nest

### DIFF
--- a/SR-Unlimited/data/scenes/the docks3.srt.txt
+++ b/SR-Unlimited/data/scenes/the docks3.srt.txt
@@ -18070,45 +18070,6 @@ characters {
 characters {
   name: "chars_icon_playerIcon"
   gridPoint {
-    x: -48
-    y: 0
-    z: 96
-  }
-  orientation: ORIENTATION_S
-  GeneralTags: "Clockwork"
-  idRef {
-    id: "52c97907336331280d007519"
-  }
-  lod: 0
-  character_instance {
-    prefab_name: "Seattle:Story/ThaddeusRyker"
-    character_sheet_id: "runner Clockwork"
-    equipment_sheet_id: "runner Clockwork"
-    character_mod {
-      archetypeName: "Player"
-      attitude: AttitudeAggressive
-      vulnerabilities {
-      }
-    }
-    team_id: "Shadowrunners"
-    char_name: "Clockwork"
-    GeneralTags: "Clockwork"
-    enabled_at_start: false
-    pc_spawn_number: -1
-    hiring_type: HiringType_None
-    cyberware_eyes: "Vision Magnification Eyes 2"
-    cyberware_jack: "Datajack"
-    cyberware_right_arm: "Obvious Cyberarm"
-    portrait {
-      filename: "backer_humanmale_jamestbenton"
-    }
-    karma: 77
-    hiring_cost_override: 1000
-  }
-}
-characters {
-  name: "chars_icon_playerIcon"
-  gridPoint {
     x: -86
     y: 0
     z: -9

--- a/SR-Unlimited/data/scenes/the rat's nest.srt.txt
+++ b/SR-Unlimited/data/scenes/the rat's nest.srt.txt
@@ -16838,45 +16838,6 @@ characters {
 characters {
   name: "chars_icon_playerIcon"
   gridPoint {
-    x: -48
-    y: 0
-    z: 96
-  }
-  orientation: ORIENTATION_S
-  GeneralTags: "Clockwork"
-  idRef {
-    id: "52c97907336331280d007519"
-  }
-  lod: 0
-  character_instance {
-    prefab_name: "Seattle:Story/ThaddeusRyker"
-    character_sheet_id: "runner Clockwork"
-    equipment_sheet_id: "runner Clockwork"
-    character_mod {
-      archetypeName: "Player"
-      attitude: AttitudeAggressive
-      vulnerabilities {
-      }
-    }
-    team_id: "Shadowrunners"
-    char_name: "Clockwork"
-    GeneralTags: "Clockwork"
-    enabled_at_start: false
-    pc_spawn_number: -1
-    hiring_type: HiringType_None
-    cyberware_eyes: "Vision Magnification Eyes 2"
-    cyberware_jack: "Datajack"
-    cyberware_right_arm: "Obvious Cyberarm"
-    portrait {
-      filename: "backer_humanmale_jamestbenton"
-    }
-    karma: 77
-    hiring_cost_override: 1000
-  }
-}
-characters {
-  name: "chars_icon_playerIcon"
-  gridPoint {
     x: -86
     y: 0
     z: -9


### PR DESCRIPTION
Clockwork was present twice in these scenes.
Log Entries:
"PLYR [DEBUG] occupy boundingbox ID+0 X, Z"
"PLYR [ERROR] Cant find tile to create ID+1 Clockwork" 
The character at those coords is kept, the other is deleted.

**## WARNING ##**
This is an untested change.
 
Maybe one day i install qt4 so the editor works. But not today,