### PR TITLE
HK: Disable northside "Johnson Trigger" region at start

### DIFF
--- a/SR-Unlimited/data/scenes/Hub-Northside.srt.txt
+++ b/SR-Unlimited/data/scenes/Hub-Northside.srt.txt
@@ -21483,7 +21483,7 @@ regions {
     width: -11
     height: 6
   }
-  enabledAtStart: true
+  enabledAtStart: false
   is_camera_region: false
   idRef {
     id: "520d198b336331f4020032d2"


### PR DESCRIPTION
This region at the east of Northside should be disabled at start similar to the one in Redmond. 

It is conditionally enabled by the "Mr. Johnson" trigger which also spawns the actors. 
Entering it starts a conversation with Mr. Johnson, which increments the run step. 
That creates wacky behaviour when one walks into it during other runs.